### PR TITLE
Split powder_files into source and external files

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+---
+Checks:          '-*'
+WarningsAsErrors: true
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
 ---
-Checks:          '-*'
+Checks:          '-*,modernize-use-nullptr'
 WarningsAsErrors: true
 ...

--- a/meson.build
+++ b/meson.build
@@ -436,6 +436,9 @@ project_export_dynamic = false
 subdir('src')
 subdir('resources')
 
+powder_files = []
+powder_files += powder_external_files
+powder_files += powder_source_files
 powder_files += data_files
 render_files += data_files
 font_files += data_files

--- a/meson.build
+++ b/meson.build
@@ -558,3 +558,19 @@ if get_option('build_font')
 		link_depends: copied_dlls,
 	)
 endif
+
+if get_option('clang_tidy')
+	clang_tidy = find_program('run-clang-tidy', required: false)
+
+	if clang_tidy.found()
+		run_target('clang-tidy',
+			command: [
+				clang_tidy,
+				'-p', meson.project_build_root(),
+				'-config-file', files('.clang-tidy'),
+				'-quiet',
+				powder_source_files
+			]
+		)
+	endif
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -311,3 +311,9 @@ option(
 	value: false,
 	description: 'Export Lua symbols to enable loading of Lua shared modules'
 )
+option(
+	'clang_tidy',
+	type: 'boolean',
+	value: true,
+	description: 'Run clang-tidy to lint programming issues'
+)

--- a/resources/meson.build
+++ b/resources/meson.build
@@ -83,7 +83,7 @@ if host_platform == 'windows'
 	rc_conf_data.set('WINUTF8_XML', winutf8_xml_path)
 	rc_conf_data.set('ICON_EXE_ICO', icon_exe_ico_path)
 	rc_conf_data.set('ICON_CPS_ICO', icon_cps_ico_path)
-	powder_files += windows_mod.compile_resources(
+	powder_external_files += windows_mod.compile_resources(
 		configure_file(
 			input: 'powder-res.template.rc',
 			output: 'powder-res.rc',

--- a/src/Format.cpp
+++ b/src/Format.cpp
@@ -30,7 +30,7 @@ ByteString format::UnixtimeToDate(time_t unixtime, ByteString dateFormat, bool l
 
 ByteString format::UnixtimeToDateMini(time_t unixtime)
 {
-	time_t currentTime = time(NULL);
+	time_t currentTime = time(nullptr);
 	struct tm currentTimeData = *gmtime(&currentTime);
 	struct tm timeData = *gmtime(&unixtime);
 
@@ -135,10 +135,10 @@ static std::unique_ptr<PlaneAdapter<std::vector<uint32_t>>> readPNG(
 {
 	png_infop info = nullptr;
 	auto deleter = [&info](png_struct *png) {
-		png_destroy_read_struct(&png, &info, NULL);
+		png_destroy_read_struct(&png, &info, nullptr);
 	};
 	auto png = std::unique_ptr<png_struct, decltype(deleter)>(
-		png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL,
+		png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr,
 			[](png_structp png, png_const_charp msg) {
 				fprintf(stderr, "PNG error: %s\n", msg);
 			},
@@ -235,7 +235,7 @@ std::unique_ptr<std::vector<char>> format::PixelsToPNG(PlaneAdapter<std::vector<
 		png_destroy_write_struct(&png, &info);
 	};
 	auto png = std::unique_ptr<png_struct, decltype(deleter)>(
-		png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL,
+		png_create_write_struct(PNG_LIBPNG_VER_STRING, nullptr,
 			[](png_structp png, png_const_charp msg) {
 				fprintf(stderr, "PNG error: %s\n", msg);
 			},
@@ -272,13 +272,13 @@ std::unique_ptr<std::vector<char>> format::PixelsToPNG(PlaneAdapter<std::vector<
 
 	png_set_write_fn(png.get(), static_cast<void *>(&writeFn), [](png_structp png, png_bytep data, size_t length) {
 		(*static_cast<decltype(writeFn) *>(png_get_io_ptr(png)))(png, data, length);
-	}, NULL);
+	}, nullptr);
 	png_set_IHDR(png.get(), info, input.Size().X, input.Size().Y, 8, PNG_COLOR_TYPE_RGB, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
 	png_write_info(png.get(), info);
 	png_set_filler(png.get(), 0x00, PNG_FILLER_AFTER);
 	png_set_bgr(png.get());
 	png_write_image(png.get(), const_cast<png_bytepp>(rowPointers.data()));
-	png_write_end(png.get(), NULL);
+	png_write_end(png.get(), nullptr);
 
 	return std::make_unique<std::vector<char>>(std::move(output));
 }

--- a/src/PowderToy.cpp
+++ b/src/PowderToy.cpp
@@ -118,7 +118,7 @@ static void BlueScreen(String detailMessage, std::optional<std::vector<String>> 
 	crashInfo << "Please attach this file to your report.\n\n";
 	crashInfo << "Version: " << VersionInfo().FromUtf8() << "\n";
 	crashInfo << "Tag: " << VCS_TAG << "\n";
-	crashInfo << "Date: " << format::UnixtimeToDate(time(NULL), "%Y-%m-%dT%H:%M:%SZ", false).FromUtf8() << "\n";
+	crashInfo << "Date: " << format::UnixtimeToDate(time(nullptr), "%Y-%m-%dT%H:%M:%SZ", false).FromUtf8() << "\n";
 	if (stackTrace)
 	{
 		crashInfo << "Stack trace; main is at 0x" << Format::Hex() << intptr_t(main) << ":\n";

--- a/src/PowderToySDL.cpp
+++ b/src/PowderToySDL.cpp
@@ -10,9 +10,9 @@
 
 int desktopWidth = 1280;
 int desktopHeight = 1024;
-SDL_Window *sdl_window = NULL;
-SDL_Renderer *sdl_renderer = NULL;
-SDL_Texture *sdl_texture = NULL;
+SDL_Window *sdl_window = nullptr;
+SDL_Renderer *sdl_renderer = nullptr;
+SDL_Texture *sdl_texture = nullptr;
 bool vsyncHint = false;
 WindowFrameOps currentFrameOps;
 bool momentumScroll = true;
@@ -99,11 +99,11 @@ static void CalculateMousePosition(int *x, int *y)
 
 void blit(pixel *vid)
 {
-	SDL_UpdateTexture(sdl_texture, NULL, vid, WINDOWW * sizeof (Uint32));
+	SDL_UpdateTexture(sdl_texture, nullptr, vid, WINDOWW * sizeof (Uint32));
 	// need to clear the renderer if there are black edges (fullscreen, or resizable window)
 	if (currentFrameOps.fullscreen || currentFrameOps.resizable)
 		SDL_RenderClear(sdl_renderer);
-	SDL_RenderCopy(sdl_renderer, sdl_texture, NULL, NULL);
+	SDL_RenderCopy(sdl_renderer, sdl_texture, nullptr, nullptr);
 	SDL_RenderPresent(sdl_renderer);
 }
 
@@ -141,7 +141,7 @@ void SDLClose()
 		//   sdl closes the display. this is an nvidia driver weirdness but
 		//   technically an sdl bug. glfw has this fixed:
 		//   https://github.com/glfw/glfw/commit/9e6c0c747be838d1f3dc38c2924a47a42416c081
-		SDL_GL_LoadLibrary(NULL);
+		SDL_GL_LoadLibrary(nullptr);
 		SDL_QuitSubSystem(SDL_INIT_VIDEO);
 		SDL_GL_UnloadLibrary();
 	}
@@ -197,18 +197,18 @@ void SDLSetScreen()
 		if (sdl_texture)
 		{
 			SDL_DestroyTexture(sdl_texture);
-			sdl_texture = NULL;
+			sdl_texture = nullptr;
 		}
 		if (sdl_renderer)
 		{
 			SDL_DestroyRenderer(sdl_renderer);
-			sdl_renderer = NULL;
+			sdl_renderer = nullptr;
 		}
 		if (sdl_window)
 		{
 			SaveWindowPosition();
 			SDL_DestroyWindow(sdl_window);
-			sdl_window = NULL;
+			sdl_window = nullptr;
 		}
 
 		unsigned int flags = 0;

--- a/src/bson/BSON.cpp
+++ b/src/bson/BSON.cpp
@@ -40,8 +40,8 @@ static int _bson_errprintf( const char *, ... );
 bson_printf_func bson_errprintf = _bson_errprintf;
 
 /* ObjectId fuzz functions. */
-static int ( *oid_fuzz_func )( void ) = NULL;
-static int ( *oid_inc_func )( void )  = NULL;
+static int ( *oid_fuzz_func )( void ) = nullptr;
+static int ( *oid_inc_func )( void )  = nullptr;
 
 /* ----------------------------
    READING
@@ -89,7 +89,7 @@ static void _bson_reset( bson *b ) {
 	b->finished = 0;
 	b->stackPos = 0;
 	b->err = 0;
-	b->errstr = NULL;
+	b->errstr = nullptr;
 }
 
 int bson_size( const bson *b ) {
@@ -178,7 +178,7 @@ void bson_oid_gen( bson_oid_t *oid ) {
 	static int incr = 0;
 	static int fuzz = 0;
 	int i;
-	int t = time( NULL );
+	int t = time( nullptr );
 
 	if( oid_inc_func )
 		i = oid_inc_func();
@@ -305,7 +305,7 @@ void bson_iterator_init( bson_iterator *i, const bson *b ) {
 void bson_iterator_from_buffer( bson_iterator *i, const char *buffer ) {
 	i->cur = buffer + 4;
 	i->first = 1;
-	i->last = NULL;
+	i->last = nullptr;
 }
 
 bson_type bson_find( bson_iterator *it, const bson *obj, const char *name ) {
@@ -515,7 +515,7 @@ const char *bson_iterator_code( const bson_iterator *i ) {
 	case BSON_CODEWSCOPE:
 		return bson_iterator_value( i ) + 8;
 	default:
-		return NULL;
+		return nullptr;
 	}
 }
 
@@ -581,7 +581,7 @@ void bson_iterator_subiterator( const bson_iterator *i, bson_iterator *sub ) {
 
 static void _bson_init_size( bson *b, int size ) {
 	if( size == 0 )
-		b->data = NULL;
+		b->data = nullptr;
 	else
 		b->data = ( char * )bson_malloc( size );
 	b->dataSize = size;
@@ -667,8 +667,8 @@ void bson_destroy( bson *b ) {
 	if (b->data)
 		bson_free( b->data );
 	b->err = 0;
-	b->data = 0;
-	b->cur = 0;
+	b->data = nullptr;
+	b->cur = nullptr;
 	b->finished = 1;
 }
 
@@ -853,7 +853,7 @@ int bson_append_element( bson *b, const char *name_or_null, const bson_iterator 
 	bson_iterator_next( &next );
 	size = next.cur - elem->cur;
 
-	if ( name_or_null == NULL ) {
+	if ( name_or_null == nullptr ) {
 		if( bson_ensure_space( b, size ) == BSON_ERROR )
 			return BSON_ERROR;
 		bson_append( b, elem->cur, size );
@@ -919,7 +919,7 @@ int bson_append_finish_array( bson *b ) {
 
 /* Error handling and allocators. */
 
-static bson_err_handler err_handler = NULL;
+static bson_err_handler err_handler = nullptr;
 
 bson_err_handler set_bson_err_handler( bson_err_handler func ) {
 	bson_err_handler old = err_handler;

--- a/src/bzip2/bz2wrap.cpp
+++ b/src/bzip2/bz2wrap.cpp
@@ -10,9 +10,9 @@ static size_t outputSizeIncrement = 0x100000U;
 BZ2WCompressResult BZ2WCompress(std::vector<char> &dest, const char *srcData, size_t srcSize, size_t maxSize)
 {
 	bz_stream stream;
-	stream.bzalloc = NULL;
-	stream.bzfree = NULL;
-	stream.opaque = NULL;
+	stream.bzalloc = nullptr;
+	stream.bzfree = nullptr;
+	stream.opaque = nullptr;
 	if (BZ2_bzCompressInit(&stream, 9, 0, 0) != BZ_OK)
 	{
 		return BZ2WCompressNomem;
@@ -56,9 +56,9 @@ BZ2WCompressResult BZ2WCompress(std::vector<char> &dest, const char *srcData, si
 BZ2WDecompressResult BZ2WDecompress(std::vector<char> &dest, const char *srcData, size_t srcSize, size_t maxSize)
 {
 	bz_stream stream;
-	stream.bzalloc = NULL;
-	stream.bzfree = NULL;
-	stream.opaque = NULL;
+	stream.bzalloc = nullptr;
+	stream.bzfree = nullptr;
+	stream.opaque = nullptr;
 	if (BZ2_bzDecompressInit(&stream, 0, 0) != BZ_OK)
 	{
 		return BZ2WDecompressNomem;

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -310,7 +310,7 @@ void Client::RenameStamp(ByteString stampID, ByteString newName)
 
 ByteString Client::AddStamp(std::unique_ptr<GameSave> saveData)
 {
-	auto now = (uint64_t)time(NULL);
+	auto now = (uint64_t)time(nullptr);
 	if (lastStampTime != now)
 	{
 		lastStampTime = now;

--- a/src/client/GameSave.cpp
+++ b/src/client/GameSave.cpp
@@ -445,7 +445,7 @@ void GameSave::readOPS(const std::vector<char> &data)
 	unsigned char *fanData = nullptr;
 	unsigned char *wallData = nullptr;
 	unsigned char *soapLinkData = nullptr;
-	unsigned char *pressData = NULL, *vxData = NULL, *vyData = NULL, *ambientData = NULL, *blockAirData = nullptr, *gravityData = nullptr;
+	unsigned char *pressData = nullptr, *vxData = nullptr, *vyData = nullptr, *ambientData = nullptr, *blockAirData = nullptr, *gravityData = nullptr;
 	unsigned int inputDataLen = data.size(), bsonDataLen = 0, partsDataLen, partsPosDataLen, fanDataLen, wallDataLen, soapLinkDataLen;
 	unsigned int pressDataLen, vxDataLen, vyDataLen, ambientDataLen, blockAirDataLen, gravityDataLen;
 	unsigned partsCount = 0;
@@ -454,7 +454,7 @@ void GameSave::readOPS(const std::vector<char> &data)
 	bool fakeNewerVersion = false; // used for development builds only
 
 	bson b;
-	b.data = NULL;
+	b.data = nullptr;
 	auto bson_deleter = [](bson * b) { bson_destroy(b); };
 	// Use unique_ptr with a custom deleter to ensure that bson_destroy is called even when an exception is thrown
 	std::unique_ptr<bson, decltype(bson_deleter)> b_ptr(&b, bson_deleter);
@@ -2471,7 +2471,7 @@ std::pair<bool, std::vector<char>> GameSave::serialiseOPS() const
 	}
 
 	bson b;
-	b.data = NULL;
+	b.data = nullptr;
 	auto bson_deleter = [](bson * b) { bson_destroy(b); };
 	// Use unique_ptr with a custom deleter to ensure that bson_destroy is called even when an exception is thrown
 	std::unique_ptr<bson, decltype(bson_deleter)> b_ptr(&b, bson_deleter);

--- a/src/client/http/SearchSavesRequest.cpp
+++ b/src/client/http/SearchSavesRequest.cpp
@@ -19,7 +19,7 @@ namespace http
 			query += str;
 		};
 
-		time_t currentTime = time(NULL);
+		time_t currentTime = time(nullptr);
 
 		if(period)
 		{

--- a/src/client/http/requestmanager/Libcurl.cpp
+++ b/src/client/http/requestmanager/Libcurl.cpp
@@ -52,14 +52,14 @@ namespace http
 
 	struct RequestHandleHttp : public RequestHandle
 	{
-		curl_slist *curlHeaders = NULL;
+		curl_slist *curlHeaders = nullptr;
 #ifdef REQUEST_USE_CURL_MIMEPOST
-		curl_mime *curlPostFields = NULL;
+		curl_mime *curlPostFields = nullptr;
 #else
 		curl_httppost *curlPostFieldsFirst = NULL;
 		curl_httppost *curlPostFieldsLast = NULL;
 #endif
-		CURL *curlEasy = NULL;
+		CURL *curlEasy = nullptr;
 		char curlErrorBuffer[CURL_ERROR_SIZE];
 		bool curlAddedToMulti = false;
 		bool gotStatusLine = false;
@@ -139,7 +139,7 @@ namespace http
 		void UnregisterRequestHandle(std::shared_ptr<RequestHandle> requestHandle);
 
 		bool curlGlobalInit = false;
-		CURLM *curlMulti = NULL;
+		CURLM *curlMulti = nullptr;
 
 		void Wake()
 		{
@@ -152,7 +152,7 @@ namespace http
 		{
 			int dontcare;
 #ifdef REQUEST_USE_CURL_MULTI_POLL
-			HandleCURLMcode(curl_multi_poll(curlMulti, NULL, 0, 100000, &dontcare));
+			HandleCURLMcode(curl_multi_poll(curlMulti, nullptr, 0, 100000, &dontcare));
 #else
 			constexpr auto TickMs = 100;
 			if (requestHandles.size())
@@ -285,7 +285,7 @@ namespace http
 	void RequestManagerImpl::WorkerExit()
 	{
 		curl_multi_cleanup(curlMulti);
-		curlMulti = NULL;
+		curlMulti = nullptr;
 		curl_global_cleanup();
 	}
 

--- a/src/client/meson.build
+++ b/src/client/meson.build
@@ -14,7 +14,7 @@ endif
 
 subdir('http')
 
-powder_files += client_files
+powder_source_files += client_files
 
 render_files += files(
 	'GameSave.cpp',

--- a/src/common/clipboard/meson.build
+++ b/src/common/clipboard/meson.build
@@ -1,7 +1,7 @@
 if platform_clipboard
 	clipboard_impl_factories = []
 	if host_platform == 'windows'
-		powder_files += files('Windows.cpp')
+		powder_source_files += files('Windows.cpp')
 		clipboard_impl_factories += [
 			[ 'SDL_SYSWM_WINDOWS', 'WindowsClipboardFactory' ],
 		]
@@ -12,7 +12,7 @@ if platform_clipboard
 				dependency('Cocoa'),
 			]
 		endif
-		powder_files += files([
+		powder_source_files += files([
 			'Cocoa.mm',
 		])
 		clipboard_impl_factories += [
@@ -23,7 +23,7 @@ if platform_clipboard
 	elif host_platform == 'emscripten'
 		# TODO
 	else
-		powder_files += files([
+		powder_source_files += files([
 			'External.cpp',
 		])
 		clipboard_impl_factories += [
@@ -31,9 +31,9 @@ if platform_clipboard
 			[ 'SDL_SYSWM_WAYLAND', 'ExternalClipboardFactory' ],
 		]
 	endif
-	powder_files += files('Dynamic.cpp')
+	powder_source_files += files('Dynamic.cpp')
 else
-	powder_files += files('Null.cpp')
+	powder_source_files += files('Null.cpp')
 endif
 render_files += files('Null.cpp')
 font_files += files('Null.cpp')

--- a/src/common/platform/DdirCommon.cpp
+++ b/src/common/platform/DdirCommon.cpp
@@ -8,7 +8,7 @@ namespace Platform
 {
 ByteString DefaultDdir()
 {
-	auto ddir = std::unique_ptr<char, decltype(&SDL_free)>(SDL_GetPrefPath(NULL, APPDATA), SDL_free);
+	auto ddir = std::unique_ptr<char, decltype(&SDL_free)>(SDL_GetPrefPath(nullptr, APPDATA), SDL_free);
 	return ddir.get();
 }
 }

--- a/src/common/platform/Posix.cpp
+++ b/src/common/platform/Posix.cpp
@@ -12,7 +12,7 @@ namespace Platform
 ByteString GetCwd()
 {
 	ByteString cwd;
-	char *cwdPtr = getcwd(NULL, 0);
+	char *cwdPtr = getcwd(nullptr, 0);
 	if (cwdPtr)
 	{
 		cwd = cwdPtr;
@@ -26,7 +26,7 @@ void Millisleep(long int t)
 	struct timespec s;
 	s.tv_sec = t / 1000;
 	s.tv_nsec = (t % 1000) * 10000000;
-	nanosleep(&s, NULL);
+	nanosleep(&s, nullptr);
 }
 
 bool Stat(ByteString filename)

--- a/src/common/platform/PosixProc.cpp
+++ b/src/common/platform/PosixProc.cpp
@@ -28,7 +28,7 @@ void DoRestart()
 ByteString ExecutableName()
 {
 	auto firstApproximation = ExecutableNameFirstApprox();
-	auto rp = std::unique_ptr<char, decltype(std::free) *>(realpath(firstApproximation.data(), NULL), std::free);
+	auto rp = std::unique_ptr<char, decltype(std::free) *>(realpath(firstApproximation.data(), nullptr), std::free);
 	if (!rp)
 	{
 		std::cerr << "realpath: " << errno << std::endl;

--- a/src/common/platform/meson.build
+++ b/src/common/platform/meson.build
@@ -16,7 +16,7 @@ if host_platform == 'windows'
 		'Windows.cpp',
 		'ExitCommon.cpp',
 	)
-	powder_files += files(
+	powder_source_files += files(
 		'MainCommon.cpp',
 		'DdirCommon.cpp',
 	)
@@ -28,7 +28,7 @@ elif host_platform == 'darwin'
 		'PosixProc.cpp',
 		'ExitCommon.cpp',
 	)
-	powder_files += files(
+	powder_source_files += files(
 		'MainCommon.cpp',
 		'DdirCommon.cpp',
 	)
@@ -40,7 +40,7 @@ elif host_platform == 'android'
 		'PosixProc.cpp',
 		'ExitCommon.cpp',
 	)
-	powder_files += files(
+	powder_source_files += files(
 		'MainCommon.cpp',
 	)
 elif host_platform == 'emscripten'
@@ -59,7 +59,7 @@ elif host_platform == 'linux'
 		'PosixProc.cpp',
 		'ExitCommon.cpp',
 	)
-	powder_files += files(
+	powder_source_files += files(
 		'MainCommon.cpp',
 		'DdirCommon.cpp',
 	)
@@ -71,7 +71,7 @@ else
 		'PosixProc.cpp',
 		'ExitCommon.cpp',
 	)
-	powder_files += files(
+	powder_source_files += files(
 		'MainCommon.cpp',
 		'DdirCommon.cpp',
 	)

--- a/src/common/tpt-rand.cpp
+++ b/src/common/tpt-rand.cpp
@@ -52,7 +52,7 @@ float RNG::uniform01()
 
 RNG::RNG()
 {
-	s[0] = time(NULL);
+	s[0] = time(nullptr);
 	s[1] = 614;
 }
 

--- a/src/debug/SurfaceNormals.cpp
+++ b/src/debug/SurfaceNormals.cpp
@@ -36,7 +36,7 @@ void SurfaceNormals::Draw()
 		{
 			return;
 		}
-		if (sim->eval_move(PT_PHOT, mr.fin_x, mr.fin_y, NULL))
+		if (sim->eval_move(PT_PHOT, mr.fin_x, mr.fin_y, nullptr))
 		{
 			int rt = TYP(sim->pmap[mr.fin_y][mr.fin_x]);
 			int lt = TYP(sim->pmap[y][x]);

--- a/src/debug/meson.build
+++ b/src/debug/meson.build
@@ -1,4 +1,4 @@
-powder_files += files(
+powder_source_files += files(
 	'DebugLines.cpp',
 	'DebugParts.cpp',
 	'ElementPopulation.cpp',

--- a/src/graphics/Graphics.cpp
+++ b/src/graphics/Graphics.cpp
@@ -56,7 +56,7 @@ void VideoBuffer::Resize(Vec2<int> size, bool resample)
 	if (resample)
 	{
 		std::array<std::unique_ptr<Resampler>, PIXELCHANNELS> resamplers;
-		Resampler::Contrib_List *clist_x = NULL, *clist_y = NULL;
+		Resampler::Contrib_List *clist_x = nullptr, *clist_y = nullptr;
 		for (auto &ptr : resamplers)
 		{
 			ptr = std::make_unique<Resampler>(

--- a/src/graphics/meson.build
+++ b/src/graphics/meson.build
@@ -8,6 +8,6 @@ powder_graphics_files = files(
 	'Renderer.cpp',
 )
 
-powder_files += graphics_files + powder_graphics_files
+powder_source_files += graphics_files + powder_graphics_files
 render_files += graphics_files + powder_graphics_files
 font_files += graphics_files

--- a/src/gui/colourpicker/meson.build
+++ b/src/gui/colourpicker/meson.build
@@ -1,3 +1,3 @@
-powder_files += files(
+powder_source_files += files(
 	'ColourPickerActivity.cpp',
 )

--- a/src/gui/console/ConsoleView.cpp
+++ b/src/gui/console/ConsoleView.cpp
@@ -12,7 +12,7 @@
 
 ConsoleView::ConsoleView():
 	ui::Window(ui::Point(0, 0), ui::Point(WINDOWW, 150)),
-	commandField(NULL)
+	commandField(nullptr)
 {
 	commandField = new ui::Textbox(ui::Point(0, Size.Y-16), ui::Point(Size.X, 16), "");
 	commandField->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;

--- a/src/gui/console/meson.build
+++ b/src/gui/console/meson.build
@@ -1,4 +1,4 @@
-powder_files += files(
+powder_source_files += files(
 	'ConsoleController.cpp',
 	'ConsoleModel.cpp',
 	'ConsoleView.cpp',

--- a/src/gui/elementsearch/ElementSearchActivity.cpp
+++ b/src/gui/elementsearch/ElementSearchActivity.cpp
@@ -20,7 +20,7 @@
 
 ElementSearchActivity::ElementSearchActivity(GameController * gameController, std::vector<Tool*> tools) :
 	WindowActivity(ui::Point(-1, -1), ui::Point(236, 302)),
-	firstResult(NULL),
+	firstResult(nullptr),
 	gameController(gameController),
 	tools(tools),
 	toolTip(""),
@@ -61,7 +61,7 @@ ElementSearchActivity::ElementSearchActivity(GameController * gameController, st
 
 void ElementSearchActivity::searchTools(String query)
 {
-	firstResult = NULL;
+	firstResult = nullptr;
 	for (auto &toolButton : toolButtons) {
 		scrollPanel->RemoveChild(toolButton);
 		delete toolButton;

--- a/src/gui/elementsearch/meson.build
+++ b/src/gui/elementsearch/meson.build
@@ -1,3 +1,3 @@
-powder_files += files(
+powder_source_files += files(
 	'ElementSearchActivity.cpp',
 )

--- a/src/gui/filebrowser/FileBrowserActivity.cpp
+++ b/src/gui/filebrowser/FileBrowserActivity.cpp
@@ -212,7 +212,7 @@ void FileBrowserActivity::NotifyDone(Task * task)
 	createButtons = true;
 	totalFiles = files.size();
 	delete loadFiles;
-	loadFiles = NULL;
+	loadFiles = nullptr;
 	if (!files.size())
 	{
 		progressBar->Visible = false;

--- a/src/gui/filebrowser/meson.build
+++ b/src/gui/filebrowser/meson.build
@@ -1,3 +1,3 @@
-powder_files += files(
+powder_source_files += files(
 	'FileBrowserActivity.cpp',
 )

--- a/src/gui/game/GameController.cpp
+++ b/src/gui/game/GameController.cpp
@@ -71,14 +71,14 @@
 GameController::GameController():
 	firstTick(true),
 	foundSignID(-1),
-	activePreview(NULL),
-	search(NULL),
-	renderOptions(NULL),
-	loginWindow(NULL),
-	console(NULL),
-	tagsWindow(NULL),
-	localBrowser(NULL),
-	options(NULL),
+	activePreview(nullptr),
+	search(nullptr),
+	renderOptions(nullptr),
+	loginWindow(nullptr),
+	console(nullptr),
+	tagsWindow(nullptr),
+	localBrowser(nullptr),
+	options(nullptr),
 	debugFlags(0),
 	HasDone(false)
 {
@@ -484,7 +484,7 @@ void GameController::CopyRegion(ui::Point point1, ui::Point point2)
 		Json::Value clipboardInfo;
 		clipboardInfo["type"] = "clipboard";
 		clipboardInfo["username"] = Client::Ref().GetAuthUser().Username;
-		clipboardInfo["date"] = (Json::Value::UInt64)time(NULL);
+		clipboardInfo["date"] = (Json::Value::UInt64)time(nullptr);
 		Client::Ref().SaveAuthorInfo(&clipboardInfo);
 		newSave->authors = clipboardInfo;
 
@@ -906,31 +906,31 @@ void GameController::Update()
 	if(renderOptions && renderOptions->HasExited)
 	{
 		delete renderOptions;
-		renderOptions = NULL;
+		renderOptions = nullptr;
 	}
 
 	if(search && search->HasExited)
 	{
 		delete search;
-		search = NULL;
+		search = nullptr;
 	}
 
 	if(activePreview && activePreview->HasExited)
 	{
 		delete activePreview;
-		activePreview = NULL;
+		activePreview = nullptr;
 	}
 
 	if(loginWindow && loginWindow->HasExited)
 	{
 		delete loginWindow;
-		loginWindow = NULL;
+		loginWindow = nullptr;
 	}
 
 	if(localBrowser && localBrowser->HasDone)
 	{
 		delete localBrowser;
-		localBrowser = NULL;
+		localBrowser = nullptr;
 	}
 }
 
@@ -1232,7 +1232,7 @@ void GameController::OpenLocalSaveWindow(bool asCurrent)
 			localSaveInfo["type"] = "localsave";
 			localSaveInfo["username"] = Client::Ref().GetAuthUser().Username;
 			localSaveInfo["title"] = gameModel->GetSaveFile()->GetName();
-			localSaveInfo["date"] = (Json::Value::UInt64)time(NULL);
+			localSaveInfo["date"] = (Json::Value::UInt64)time(nullptr);
 			Client::Ref().SaveAuthorInfo(&localSaveInfo);
 			gameSave->authors = localSaveInfo;
 
@@ -1387,7 +1387,7 @@ void GameController::OpenOptions()
 void GameController::ShowConsole()
 {
 	if (!console)
-		console = new ConsoleController(NULL, commandInterface.get());
+		console = new ConsoleController(nullptr, commandInterface.get());
 	if (console->GetView() != ui::Engine::Ref().GetWindow())
 		ui::Engine::Ref().ShowWindow(console->GetView());
 }
@@ -1401,7 +1401,7 @@ void GameController::HideConsole()
 
 void GameController::OpenRenderOptions()
 {
-	renderOptions = new RenderController(gameModel->GetSimulation(), gameModel->GetRenderer(), &gameModel->GetRendererSettings(), NULL);
+	renderOptions = new RenderController(gameModel->GetSimulation(), gameModel->GetRenderer(), &gameModel->GetRendererSettings(), nullptr);
 	ui::Engine::Ref().ShowWindow(renderOptions->GetView());
 }
 
@@ -1507,7 +1507,7 @@ void GameController::ChangeBrush()
 void GameController::ClearSim()
 {
 	HistorySnapshot();
-	gameModel->SetSave(NULL, false);
+	gameModel->SetSave(nullptr, false);
 	gameModel->ClearSimulation();
 }
 

--- a/src/gui/game/GameView.cpp
+++ b/src/gui/game/GameView.cpp
@@ -204,7 +204,7 @@ GameView::GameView():
 	recordingFolder(0),
 	currentPoint(ui::Point(0, 0)),
 	lastPoint(ui::Point(0, 0)),
-	activeBrush(NULL),
+	activeBrush(nullptr),
 	saveSimulationButtonEnabled(false),
 	saveReuploadAllowed(true),
 	drawMode(DrawPoints),
@@ -660,11 +660,11 @@ void GameView::NotifyColourSelectorVisibilityChanged(GameModel * sender)
 	{
 		ToolButton * button = *iter;
 		RemoveComponent(button);
-		button->SetParentWindow(NULL);
+		button->SetParentWindow(nullptr);
 	}
 
 	RemoveComponent(colourPicker);
-	colourPicker->SetParentWindow(NULL);
+	colourPicker->SetParentWindow(nullptr);
 
 	if(sender->GetColourSelectorVisibility())
 	{
@@ -992,7 +992,7 @@ int GameView::Record(bool record)
 	}
 	else if (!recording)
 	{
-		time_t startTime = time(NULL);
+		time_t startTime = time(nullptr);
 		recordingFolder = startTime;
 		Platform::MakeDirectory("recordings");
 		Platform::MakeDirectory(ByteString::Build("recordings", PATH_SEP_CHAR, recordingFolder));

--- a/src/gui/game/meson.build
+++ b/src/gui/game/meson.build
@@ -1,4 +1,4 @@
-powder_files += files(
+powder_source_files += files(
 	'BitmapBrush.cpp',
 	'Brush.cpp',
 	'Favorite.cpp',

--- a/src/gui/game/tool/SignTool.cpp
+++ b/src/gui/game/tool/SignTool.cpp
@@ -52,7 +52,7 @@ public:
 SignWindow::SignWindow(SignTool * tool_, Simulation * sim_, int signID_, ui::Point position_):
 	ui::Window(ui::Point(-1, -1), ui::Point(250, 87)),
 	tool(tool_),
-	movingSign(NULL),
+	movingSign(nullptr),
 	signMoving(false),
 	sim(sim_),
 	signID(signID_),

--- a/src/gui/game/tool/meson.build
+++ b/src/gui/game/tool/meson.build
@@ -1,4 +1,4 @@
-powder_files += files(
+powder_source_files += files(
 	'DecorationTool.cpp',
 	'ElementTool.cpp',
 	'GOLTool.cpp',

--- a/src/gui/interface/Component.cpp
+++ b/src/gui/interface/Component.cpp
@@ -9,13 +9,13 @@
 using namespace ui;
 
 Component::Component(Point position, Point size):
-	parentstate_(0),
-	_parent(NULL),
+	parentstate_(nullptr),
+	_parent(nullptr),
 	drawn(false),
 	textPosition(0, 0),
 	textSize(0, 0),
 	iconPosition(0, 0),
-	menu(NULL),
+	menu(nullptr),
 	Position(position),
 	Size(size),
 	Enabled(true),
@@ -93,9 +93,9 @@ void Component::SetParentWindow(Window* window)
 
 void Component::SetParent(Panel* new_parent)
 {
-	if(new_parent == NULL)
+	if(new_parent == nullptr)
 	{
-		if(_parent != NULL)
+		if(_parent != nullptr)
 		{
 			// remove from current parent and send component to parent state
 			for(int i = 0; i < _parent->GetChildCount(); ++i)

--- a/src/gui/interface/Engine.cpp
+++ b/src/gui/interface/Engine.cpp
@@ -13,7 +13,7 @@ using namespace ui;
 Engine::Engine():
 	drawingFrequencyLimit(0),
 	FrameIndex(0),
-	state_(NULL),
+	state_(nullptr),
 	windowTargetPosition(0, 0),
 	FastQuit(1),
 	lastTick(0),
@@ -131,7 +131,7 @@ int Engine::CloseWindow()
 	}
 	else
 	{
-		state_ = NULL;
+		state_ = nullptr;
 		return 1;
 	}
 }
@@ -151,7 +151,7 @@ int Engine::CloseWindow()
 
 void Engine::Tick()
 {
-	if(state_ != NULL)
+	if(state_ != nullptr)
 		state_->DoTick(dt);
 
 

--- a/src/gui/interface/Panel.cpp
+++ b/src/gui/interface/Panel.cpp
@@ -49,7 +49,7 @@ void Panel::RemoveChild(Component* c)
 			//remove child from parent. Does not free memory
 			children.erase(children.begin() + i);
 			if (this->GetParentWindow()->IsFocused(c))
-				this->GetParentWindow()->FocusComponent(NULL);
+				this->GetParentWindow()->FocusComponent(nullptr);
 			break;
 		}
 	}

--- a/src/gui/interface/ScrollPanel.cpp
+++ b/src/gui/interface/ScrollPanel.cpp
@@ -152,7 +152,7 @@ void ScrollPanel::XOnMouseMoved(int x, int y)
 				{
 					child->MouseDownInside = false;
 				}
-				GetParentWindow()->FocusComponent(NULL);
+				GetParentWindow()->FocusComponent(nullptr);
 			}
 		}
 

--- a/src/gui/interface/Window.cpp
+++ b/src/gui/interface/Window.cpp
@@ -17,10 +17,10 @@ Window::Window(Point _position, Point _size):
 	Size(_size),
 	AllowExclusiveDrawing(true),
 	DoesTextInput(false),
-	okayButton(NULL),
-	cancelButton(NULL),
-	focusedComponent_(NULL),
-	hoverComponent(NULL),
+	okayButton(nullptr),
+	cancelButton(nullptr),
+	focusedComponent_(nullptr),
+	hoverComponent(nullptr),
 	debugMode(false),
 	halt(false),
 	destruct(false),
@@ -40,7 +40,7 @@ Window::~Window()
 
 void Window::AddComponent(Component* c)
 {
-	if (c->GetParentWindow() == NULL)
+	if (c->GetParentWindow() == nullptr)
 	{
 		c->SetParentWindow(this);
 		c->MouseInside = false;
@@ -81,14 +81,14 @@ void Window::RemoveComponent(Component* c)
 			//Make sure any events don't continue
 			halt = true;
 			if (Components[i] == focusedComponent_)
-				focusedComponent_ = NULL;
+				focusedComponent_ = nullptr;
 			if (Components[i] == hoverComponent)
-				hoverComponent = NULL;
+				hoverComponent = nullptr;
 
 			Components.erase(Components.begin() + i);
 
 			// we're done
-			c->SetParentWindow(NULL);
+			c->SetParentWindow(nullptr);
 			return;
 		}
 	}
@@ -111,9 +111,9 @@ void Window::RemoveComponent(unsigned idx)
 	halt = true;
 	// free component and remove it.
 	if (Components[idx] == focusedComponent_)
-		focusedComponent_ = NULL;
+		focusedComponent_ = nullptr;
 	if (Components[idx] == hoverComponent)
-		hoverComponent = NULL;
+		hoverComponent = nullptr;
 	delete Components[idx];
 	Components.erase(Components.begin() + idx);
 }
@@ -202,9 +202,9 @@ void Window::DoDraw()
 					(focusedComponent_ == child ? 0x00FF00_rgb : 0xFF0000_rgb).WithAlpha(0x5A));
 		}
 	// the component the mouse is hovering over and the focused component are always drawn last
-	if (hoverComponent && hoverComponent->GetParent() == NULL)
+	if (hoverComponent && hoverComponent->GetParent() == nullptr)
 		drawChild(hoverComponent);
-	if (focusedComponent_ && focusedComponent_ != hoverComponent && focusedComponent_->GetParent() == NULL)
+	if (focusedComponent_ && focusedComponent_ != hoverComponent && focusedComponent_->GetParent() == nullptr)
 		drawChild(focusedComponent_);
 	if (debugMode && focusedComponent_)
 	{
@@ -282,7 +282,7 @@ void Window::DoKeyPress(int key, int scan, bool repeat, bool shift, bool ctrl, b
 		debugMode = !debugMode;
 	if (debugMode)
 	{
-		if (focusedComponent_!=NULL)
+		if (focusedComponent_!=nullptr)
 		{
 			if (shift)
 			{
@@ -362,7 +362,7 @@ void Window::DoKeyPress(int key, int scan, bool repeat, bool shift, bool ctrl, b
 		return;
 	}
 	//on key press
-	if (focusedComponent_ != NULL)
+	if (focusedComponent_ != nullptr)
 	{
 		if (focusedComponent_->Enabled && focusedComponent_->Visible)
 			focusedComponent_->OnKeyPress(key, scan, repeat, shift, ctrl, alt);
@@ -386,7 +386,7 @@ void Window::DoKeyRelease(int key, int scan, bool repeat, bool shift, bool ctrl,
 	if(debugMode)
 		return;
 	//on key unpress
-	if (focusedComponent_ != NULL)
+	if (focusedComponent_ != nullptr)
 	{
 		if (focusedComponent_->Enabled && focusedComponent_->Visible)
 			focusedComponent_->OnKeyRelease(key, scan, repeat, shift, ctrl, alt);
@@ -403,7 +403,7 @@ void Window::DoTextInput(String text)
 	if (debugMode)
 		return;
 	//on key unpress
-	if (focusedComponent_ != NULL)
+	if (focusedComponent_ != nullptr)
 	{
 		if (focusedComponent_->Enabled && focusedComponent_->Visible)
 			focusedComponent_->OnTextInput(text);
@@ -417,7 +417,7 @@ void Window::DoTextInput(String text)
 
 void Window::DoTextEditing(String text)
 {
-	if (focusedComponent_ != NULL)
+	if (focusedComponent_ != nullptr)
 	{
 		if (focusedComponent_->Enabled && focusedComponent_->Visible)
 			focusedComponent_->OnTextEditing(text);
@@ -454,7 +454,7 @@ void Window::DoMouseDown(int x_, int y_, unsigned button)
 	}
 
 	if (!clickState)
-		FocusComponent(NULL);
+		FocusComponent(nullptr);
 
 	if (debugMode)
 		return;

--- a/src/gui/interface/meson.build
+++ b/src/gui/interface/meson.build
@@ -19,7 +19,7 @@ gui_files += files(
 	'Window.cpp',
 )
 
-powder_files += files(
+powder_source_files += files(
 	'AvatarButton.cpp',
 	'RichLabel.cpp',
 	'SaveButton.cpp',

--- a/src/gui/localbrowser/meson.build
+++ b/src/gui/localbrowser/meson.build
@@ -1,4 +1,4 @@
-powder_files += files(
+powder_source_files += files(
 	'LocalBrowserController.cpp',
 	'LocalBrowserModel.cpp',
 	'LocalBrowserView.cpp',

--- a/src/gui/login/meson.build
+++ b/src/gui/login/meson.build
@@ -1,4 +1,4 @@
-powder_files += files(
+powder_source_files += files(
 	'LoginController.cpp',
 	'LoginModel.cpp',
 	'LoginView.cpp',

--- a/src/gui/meson.build
+++ b/src/gui/meson.build
@@ -21,5 +21,5 @@ subdir('search')
 subdir('tags')
 subdir('update')
 
-powder_files += gui_files
+powder_source_files += gui_files
 font_files += gui_files

--- a/src/gui/options/meson.build
+++ b/src/gui/options/meson.build
@@ -1,4 +1,4 @@
-powder_files += files(
+powder_source_files += files(
 	'OptionsController.cpp',
 	'OptionsModel.cpp',
 	'OptionsView.cpp',

--- a/src/gui/preview/PreviewController.cpp
+++ b/src/gui/preview/PreviewController.cpp
@@ -20,7 +20,7 @@
 
 PreviewController::PreviewController(int saveID, int saveDate, SavePreviewType savePreviewType, std::function<void ()> onDone_, std::unique_ptr<VideoBuffer> thumbnail):
 	saveId(saveID),
-	loginWindow(NULL),
+	loginWindow(nullptr),
 	HasExited(false)
 {
 	previewModel = new PreviewModel();
@@ -48,7 +48,7 @@ void PreviewController::Update()
 	if (loginWindow && loginWindow->HasExited == true)
 	{
 		delete loginWindow;
-		loginWindow = NULL;
+		loginWindow = nullptr;
 	}
 	if (previewModel->GetDoOpen() && previewModel->GetSaveInfo() && previewModel->GetSaveInfo()->GetGameSave())
 	{

--- a/src/gui/preview/PreviewView.cpp
+++ b/src/gui/preview/PreviewView.cpp
@@ -36,9 +36,9 @@
 
 PreviewView::PreviewView(std::unique_ptr<VideoBuffer> newSavePreview):
 	ui::Window(ui::Point(-1, -1), ui::Point((XRES/2)+210, (YRES/2)+150)),
-	submitCommentButton(NULL),
-	addCommentBox(NULL),
-	commentWarningLabel(NULL),
+	submitCommentButton(nullptr),
+	addCommentBox(nullptr),
+	commentWarningLabel(nullptr),
 	userIsAuthor(false),
 	doOpen(false),
 	doError(false),
@@ -617,7 +617,7 @@ void PreviewView::submitComment()
 		else
 		{
 			isSubmittingComment = true;
-			FocusComponent(NULL);
+			FocusComponent(nullptr);
 
 			addCommentRequest = std::make_unique<http::AddCommentRequest>(c->SaveID(), comment);
 			addCommentRequest->Start();
@@ -641,13 +641,13 @@ void PreviewView::NotifyCommentBoxEnabledChanged(PreviewModel * sender)
 	{
 		RemoveComponent(addCommentBox);
 		delete addCommentBox;
-		addCommentBox = NULL;
+		addCommentBox = nullptr;
 	}
 	if(submitCommentButton)
 	{
 		RemoveComponent(submitCommentButton);
 		delete submitCommentButton;
-		submitCommentButton = NULL;
+		submitCommentButton = nullptr;
 	}
 	if(sender->GetCommentBoxEnabled())
 	{

--- a/src/gui/preview/meson.build
+++ b/src/gui/preview/meson.build
@@ -1,4 +1,4 @@
-powder_files += files(
+powder_source_files += files(
 	'PreviewController.cpp',
 	'PreviewModel.cpp',
 	'PreviewView.cpp',

--- a/src/gui/profile/meson.build
+++ b/src/gui/profile/meson.build
@@ -1,3 +1,3 @@
-powder_files += files(
+powder_source_files += files(
 	'ProfileActivity.cpp',
 )

--- a/src/gui/render/RenderView.cpp
+++ b/src/gui/render/RenderView.cpp
@@ -21,7 +21,7 @@ public:
 
 RenderView::RenderView():
 	ui::Window(ui::Point(0, 0), ui::Point(XRES, WINDOWH)),
-	ren(NULL),
+	ren(nullptr),
 	toolTip(""),
 	toolTipPresence(0),
 	isToolTipFadingIn(false)

--- a/src/gui/render/meson.build
+++ b/src/gui/render/meson.build
@@ -1,4 +1,4 @@
-powder_files += files(
+powder_source_files += files(
 	'RenderController.cpp',
 	'RenderModel.cpp',
 	'RenderView.cpp',

--- a/src/gui/save/LocalSaveActivity.cpp
+++ b/src/gui/save/LocalSaveActivity.cpp
@@ -109,7 +109,7 @@ void LocalSaveActivity::saveWrite(ByteString finalFilename)
 	localSaveInfo["type"] = "localsave";
 	localSaveInfo["username"] = Client::Ref().GetAuthUser().Username;
 	localSaveInfo["title"] = finalFilename;
-	localSaveInfo["date"] = (Json::Value::UInt64)time(NULL);
+	localSaveInfo["date"] = (Json::Value::UInt64)time(nullptr);
 	Client::Ref().SaveAuthorInfo(&localSaveInfo);
 	{
 		auto gameSave = save->TakeGameSave();

--- a/src/gui/save/ServerSaveActivity.cpp
+++ b/src/gui/save/ServerSaveActivity.cpp
@@ -61,7 +61,7 @@ ServerSaveActivity::ServerSaveActivity(std::unique_ptr<SaveInfo> newSave, OnUplo
 	thumbnailRenderer(nullptr),
 	save(std::move(newSave)),
 	onUploaded(onUploaded_),
-	saveUploadTask(NULL)
+	saveUploadTask(nullptr)
 {
 	titleLabel = new ui::Label(ui::Point(4, 5), ui::Point((Size.X/2)-8, 16), "");
 	titleLabel->SetTextColour(style::Colour::InformationTitle);
@@ -158,7 +158,7 @@ ServerSaveActivity::ServerSaveActivity(std::unique_ptr<SaveInfo> newSave, bool s
 	thumbnailRenderer(nullptr),
 	save(std::move(newSave)),
 	onUploaded(onUploaded_),
-	saveUploadTask(NULL)
+	saveUploadTask(nullptr)
 {
 	ui::Label * titleLabel = new ui::Label(ui::Point(0, 0), Size, "Saving to server...");
 	titleLabel->SetTextColour(style::Colour::InformationTitle);
@@ -218,7 +218,7 @@ void ServerSaveActivity::AddAuthorInfo()
 	serverSaveInfo["title"] = save->GetName().ToUtf8();
 	serverSaveInfo["description"] = save->GetDescription().ToUtf8();
 	serverSaveInfo["published"] = (int)save->GetPublished();
-	serverSaveInfo["date"] = (Json::Value::UInt64)time(NULL);
+	serverSaveInfo["date"] = (Json::Value::UInt64)time(nullptr);
 	Client::Ref().SaveAuthorInfo(&serverSaveInfo);
 	{
 		auto gameSave = save->TakeGameSave();

--- a/src/gui/save/meson.build
+++ b/src/gui/save/meson.build
@@ -1,4 +1,4 @@
-powder_files += files(
+powder_source_files += files(
 	'LocalSaveActivity.cpp',
 	'ServerSaveActivity.cpp',
 )

--- a/src/gui/search/SearchController.cpp
+++ b/src/gui/search/SearchController.cpp
@@ -26,7 +26,7 @@
 #include <algorithm>
 
 SearchController::SearchController(std::function<void ()> onDone_):
-	activePreview(NULL),
+	activePreview(nullptr),
 	nextQueryTime(0.0f),
 	nextQueryDone(true),
 	instantOpen(false),
@@ -72,7 +72,7 @@ void SearchController::Update()
 	if(activePreview && activePreview->HasExited)
 	{
 		delete activePreview;
-		activePreview = NULL;
+		activePreview = nullptr;
 		if(searchModel->GetLoadedSave())
 		{
 			Exit();

--- a/src/gui/search/SearchView.cpp
+++ b/src/gui/search/SearchView.cpp
@@ -19,9 +19,9 @@
 
 SearchView::SearchView():
 	ui::Window(ui::Point(0, 0), ui::Point(WINDOWW, WINDOWH)),
-	c(NULL),
+	c(nullptr),
 	saveButtons(std::vector<ui::SaveButton*>()),
-	errorLabel(NULL),
+	errorLabel(nullptr),
 	changed(true),
 	lastChanged(0),
 	pageCount(0),
@@ -409,11 +409,11 @@ void SearchView::NotifyTagListChanged(SearchModel * sender)
 	if (motdLabel)
 	{
 		RemoveComponent(motdLabel);
-		motdLabel->SetParentWindow(NULL);
+		motdLabel->SetParentWindow(nullptr);
 	}
 
 	RemoveComponent(tagsLabel);
-	tagsLabel->SetParentWindow(NULL);
+	tagsLabel->SetParentWindow(nullptr);
 
 	for (size_t i = 0; i < tagButtons.size(); i++)
 	{
@@ -564,7 +564,7 @@ void SearchView::NotifySaveListChanged(SearchModel * sender)
 		{
 			RemoveComponent(errorLabel);
 			delete errorLabel;
-			errorLabel = NULL;
+			errorLabel = nullptr;
 		}
 		for (size_t i = 0; i < saveButtons.size(); i++)
 		{

--- a/src/gui/search/meson.build
+++ b/src/gui/search/meson.build
@@ -1,4 +1,4 @@
-powder_files += files(
+powder_source_files += files(
 	'SearchController.cpp',
 	'SearchModel.cpp',
 	'SearchView.cpp',

--- a/src/gui/tags/meson.build
+++ b/src/gui/tags/meson.build
@@ -1,4 +1,4 @@
-powder_files += files(
+powder_source_files += files(
 	'TagsController.cpp',
 	'TagsModel.cpp',
 	'TagsView.cpp',

--- a/src/gui/update/meson.build
+++ b/src/gui/update/meson.build
@@ -1,3 +1,3 @@
-powder_files += files(
+powder_source_files += files(
 	'UpdateActivity.cpp',
 )

--- a/src/lua/LuaButton.cpp
+++ b/src/lua/LuaButton.cpp
@@ -12,7 +12,7 @@ Luna<LuaButton>::RegType LuaButton::methods[] = {
 	method(LuaButton, size),
 	method(LuaButton, visible),
 	method(LuaButton, enabled),
-	{0, 0}
+	{nullptr, nullptr}
 };
 
 LuaButton::LuaButton(lua_State *L) :

--- a/src/lua/LuaBz2.cpp
+++ b/src/lua/LuaBz2.cpp
@@ -47,10 +47,10 @@ void LuaBz2::Open(lua_State *L)
 		LFUNC(compress),
 		LFUNC(decompress),
 #undef LFUNC
-		{ NULL, NULL }
+		{ nullptr, nullptr }
 	};
 	lua_newtable(L);
-	luaL_register(L, NULL, reg);
+	luaL_register(L, nullptr, reg);
 #define LCONSTAS(k, v) lua_pushinteger(L, int(v)); lua_setfield(L, -2, k)
 	LCONSTAS("COMPRESS_NOMEM"  , BZ2WCompressNomem  );
 	LCONSTAS("COMPRESS_LIMIT"  , BZ2WCompressLimit  );

--- a/src/lua/LuaCheckbox.cpp
+++ b/src/lua/LuaCheckbox.cpp
@@ -12,7 +12,7 @@ Luna<LuaCheckbox>::RegType LuaCheckbox::methods[] = {
 	method(LuaCheckbox, size),
 	method(LuaCheckbox, visible),
 	method(LuaCheckbox, checked),
-	{0, 0}
+	{nullptr, nullptr}
 };
 
 LuaCheckbox::LuaCheckbox(lua_State *L) :

--- a/src/lua/LuaElements.cpp
+++ b/src/lua/LuaElements.cpp
@@ -856,10 +856,10 @@ void LuaElements::Open(lua_State *L)
 		LFUNC(getByName),
 #undef LFUNC
 		{ "free", ffree },
-		{ NULL, NULL }
+		{ nullptr, nullptr }
 	};
 	lua_newtable(L);
-	luaL_register(L, NULL, reg);
+	luaL_register(L, nullptr, reg);
 #define LCONST(v) lua_pushinteger(L, int(v)); lua_setfield(L, -2, #v)
 #define LCONSTAS(k, v) lua_pushinteger(L, int(v)); lua_setfield(L, -2, k)
 	LCONST(TYPE_PART);

--- a/src/lua/LuaEvent.cpp
+++ b/src/lua/LuaEvent.cpp
@@ -59,10 +59,10 @@ void LuaEvent::Open(lua_State *L)
 		LFUNC(getModifiers),
 #undef LFUNC
 		{ "register", fregister },
-		{ NULL, NULL }
+		{ nullptr, nullptr }
 	};
 	lua_newtable(L);
-	luaL_register(L, NULL, reg);
+	luaL_register(L, nullptr, reg);
 #define LVICONST(id, v) lua_pushinteger(L, VariantIndex<GameControllerEvent, id>()); lua_setfield(L, -2, v)
 	LVICONST(TextInputEvent    , "TEXTINPUT"    );
 	LVICONST(TextEditingEvent  , "TEXTEDITING"  );

--- a/src/lua/LuaFileSystem.cpp
+++ b/src/lua/LuaFileSystem.cpp
@@ -109,10 +109,10 @@ void LuaFileSystem::Open(lua_State *L)
 		LFUNC(move),
 		LFUNC(copy),
 #undef LFUNC
-		{ NULL, NULL }
+		{ nullptr, nullptr }
 	};
 	lua_newtable(L);
-	luaL_register(L, NULL, reg);
+	luaL_register(L, nullptr, reg);
 	lua_pushvalue(L, -1);
 	lua_setglobal(L, "fileSystem");
 	lua_setglobal(L, "fs");

--- a/src/lua/LuaGraphics.cpp
+++ b/src/lua/LuaGraphics.cpp
@@ -284,10 +284,10 @@ void LuaGraphics::Open(lua_State *L)
 		LFUNC(getHexColor),
 		LFUNC(setClipRect),
 #undef LFUNC
-		{ NULL, NULL }
+		{ nullptr, nullptr }
 	};
 	lua_newtable(L);
-	luaL_register(L, NULL, reg);
+	luaL_register(L, nullptr, reg);
 #define LCONSTAS(k, v) lua_pushinteger(L, int(v)); lua_setfield(L, -2, k)
 	LCONSTAS("WIDTH",  WINDOWW);
 	LCONSTAS("HEIGHT", WINDOWH);

--- a/src/lua/LuaHttp.cpp
+++ b/src/lua/LuaHttp.cpp
@@ -375,13 +375,13 @@ void LuaHttp::Open(lua_State *L)
 			LFUNC(cancel),
 			LFUNC(finish),
 #undef LFUNC
-			{ NULL, NULL }
+			{ nullptr, nullptr }
 		};
 		luaL_newmetatable(L, "HTTPRequest");
 		lua_pushcfunction(L, HTTPRequest_gc);
 		lua_setfield(L, -2, "__gc");
 		lua_newtable(L);
-		luaL_register(L, NULL, reg);
+		luaL_register(L, nullptr, reg);
 		lua_setfield(L, -2, "__index");
 		lua_pop(L, 1);
 	}
@@ -392,10 +392,10 @@ void LuaHttp::Open(lua_State *L)
 			LFUNC(post),
 			LFUNC(getAuthToken),
 #undef LFUNC
-			{ NULL, NULL }
+			{ nullptr, nullptr }
 		};
 		lua_newtable(L);
-		luaL_register(L, NULL, reg);
+		luaL_register(L, nullptr, reg);
 		lua_setglobal(L, "http");
 	}
 }

--- a/src/lua/LuaInterface.cpp
+++ b/src/lua/LuaInterface.cpp
@@ -490,10 +490,10 @@ void LuaInterface::Open(lua_State *L)
 		LFUNC(mousePosition),
 		LFUNC(activeTool),
 #undef LFUNC
-		{ NULL, NULL }
+		{ nullptr, nullptr }
 	};
 	lua_newtable(L);
-	luaL_register(L, NULL, reg);
+	luaL_register(L, nullptr, reg);
 #define LCONSTAS(k, v) lua_pushinteger(L, int(v)); lua_setfield(L, -2, k)
 	LCONSTAS("MOUSEUP_NORMAL" , GameController::mouseUpNormal);
 	LCONSTAS("MOUSEUP_BLUR"   , GameController::mouseUpBlur);

--- a/src/lua/LuaLabel.cpp
+++ b/src/lua/LuaLabel.cpp
@@ -10,7 +10,7 @@ Luna<LuaLabel>::RegType LuaLabel::methods[] = {
 	method(LuaLabel, position),
 	method(LuaLabel, size),
 	method(LuaLabel, visible),
-	{0, 0}
+	{nullptr, nullptr}
 };
 
 LuaLabel::LuaLabel(lua_State *L) :

--- a/src/lua/LuaMisc.cpp
+++ b/src/lua/LuaMisc.cpp
@@ -262,10 +262,10 @@ void LuaMisc::Open(lua_State *L)
 		LFUNC(compatChunk),
 #undef LFUNC
 		{ "log", flog },
-		{ NULL, NULL }
+		{ nullptr, nullptr }
 	};
 	lua_newtable(L);
-	luaL_register(L, NULL, reg);
+	luaL_register(L, nullptr, reg);
 #define LCONST(v) lua_pushinteger(L, int(v)); lua_setfield(L, -2, #v)
 	LCONST(DEBUG_PARTS);
 	LCONST(DEBUG_ELEMENTPOP);

--- a/src/lua/LuaPlatform.cpp
+++ b/src/lua/LuaPlatform.cpp
@@ -70,10 +70,10 @@ void LuaPlatform::Open(lua_State *L)
 		LFUNC(clipboardCopy),
 		LFUNC(clipboardPaste),
 #undef LFUNC
-		{ NULL, NULL }
+		{ nullptr, nullptr }
 	};
 	lua_newtable(L);
-	luaL_register(L, NULL, reg);
+	luaL_register(L, nullptr, reg);
 	lua_pushvalue(L, -1);
 	lua_setglobal(L, "platform");
 	lua_setglobal(L, "plat");

--- a/src/lua/LuaProgressBar.cpp
+++ b/src/lua/LuaProgressBar.cpp
@@ -11,7 +11,7 @@ Luna<LuaProgressBar>::RegType LuaProgressBar::methods[] = {
 	method(LuaProgressBar, visible),
 	method(LuaProgressBar, progress),
 	method(LuaProgressBar, status),
-	{0, 0}
+	{nullptr, nullptr}
 };
 
 LuaProgressBar::LuaProgressBar(lua_State *L) :

--- a/src/lua/LuaRenderer.cpp
+++ b/src/lua/LuaRenderer.cpp
@@ -248,10 +248,10 @@ void LuaRenderer::Open(lua_State *L)
 		LFUNC(useDisplayPreset),
 		LFUNC(separateThread),
 #undef LFUNC
-		{ NULL, NULL }
+		{ nullptr, nullptr }
 	};
 	lua_newtable(L);
-	luaL_register(L, NULL, reg);
+	luaL_register(L, nullptr, reg);
 #define LCONST(v) lua_pushinteger(L, int(v)); lua_setfield(L, -2, #v)
 	LCONST(PMODE);
 	LCONST(PMODE_NONE);

--- a/src/lua/LuaSimulation.cpp
+++ b/src/lua/LuaSimulation.cpp
@@ -568,7 +568,7 @@ static int createWalls(lua_State *L)
 		return luaL_error(L, "Unrecognised wall id '%d'", c);
 
 	auto *lsi = GetLSI();
-	int ret = lsi->sim->CreateWalls(x, y, rx, ry, c, NULL);
+	int ret = lsi->sim->CreateWalls(x, y, rx, ry, c, nullptr);
 	lua_pushinteger(L, ret);
 	return 1;
 }
@@ -589,7 +589,7 @@ static int createWallLine(lua_State *L)
 		return luaL_error(L, "Unrecognised wall id '%d'", c);
 
 	auto *lsi = GetLSI();
-	lsi->sim->CreateWallLine(x1, y1, x2, y2, rx, ry, c, NULL);
+	lsi->sim->CreateWallLine(x1, y1, x2, y2, rx, ry, c, nullptr);
 	return 0;
 }
 
@@ -1919,10 +1919,10 @@ void LuaSimulation::Open(lua_State *L)
 		LFUNC(fanVelocityX),
 		LFUNC(fanVelocityY),
 #undef LFUNC
-		{ NULL, NULL }
+		{ nullptr, nullptr }
 	};
 	lua_newtable(L);
-	luaL_register(L, NULL, reg);
+	luaL_register(L, nullptr, reg);
 
 #define LCONST(v) lua_pushinteger(L, int(v)); lua_setfield(L, -2, #v)
 #define LCONSTF(v) lua_pushnumber(L, float(v)); lua_setfield(L, -2, #v)

--- a/src/lua/LuaSlider.cpp
+++ b/src/lua/LuaSlider.cpp
@@ -12,7 +12,7 @@ Luna<LuaSlider>::RegType LuaSlider::methods[] = {
 	method(LuaSlider, visible),
 	method(LuaSlider, value),
 	method(LuaSlider, steps),
-	{0, 0}
+	{nullptr, nullptr}
 };
 
 LuaSlider::LuaSlider(lua_State *L) :

--- a/src/lua/LuaSocket.cpp
+++ b/src/lua/LuaSocket.cpp
@@ -18,10 +18,10 @@ void LuaSocket::Open(lua_State *L)
 	static const luaL_Reg reg[] = {
 		{ "sleep", LuaSocket::Sleep },
 		{ "getTime", LuaSocket::GetTime },
-		{ NULL, NULL }
+		{ nullptr, nullptr }
 	};
 	lua_newtable(L);
-	luaL_register(L, NULL, reg);
+	luaL_register(L, nullptr, reg);
 	lua_setglobal(L, "socket");
 	OpenTCP(L);
 }

--- a/src/lua/LuaSocketDefault.cpp
+++ b/src/lua/LuaSocketDefault.cpp
@@ -10,7 +10,7 @@ namespace LuaSocket
 	double Now()
 	{
 		struct timeval rt;
-		gettimeofday(&rt, (struct timezone *)NULL);
+		gettimeofday(&rt, (struct timezone *)nullptr);
 		return rt.tv_sec + rt.tv_usec / 1e6;
 	}
 

--- a/src/lua/LuaSocketTCPHttp.cpp
+++ b/src/lua/LuaSocketTCPHttp.cpp
@@ -622,9 +622,9 @@ namespace LuaSocket
 			{  "settimeout", LuaSocket::SetTimeout  },
 			{   "setoption", LuaSocket::SetOption   },
 			{    "shutdown", LuaSocket::Shutdown    },
-			{          NULL, NULL                      },
+			{          nullptr, nullptr                      },
 		};
-		luaL_register(L, NULL, tcpSocketIndexMethods);
+		luaL_register(L, nullptr, tcpSocketIndexMethods);
 		lua_setfield(L, -2, "__index");
 		lua_pop(L, 1);
 		lua_getglobal(L, "socket");

--- a/src/lua/LuaTextbox.cpp
+++ b/src/lua/LuaTextbox.cpp
@@ -12,7 +12,7 @@ Luna<LuaTextbox>::RegType LuaTextbox::methods[] = {
 	method(LuaTextbox, position),
 	method(LuaTextbox, size),
 	method(LuaTextbox, visible),
-	{0, 0}
+	{nullptr, nullptr}
 };
 
 LuaTextbox::LuaTextbox(lua_State *L) :

--- a/src/lua/LuaTools.cpp
+++ b/src/lua/LuaTools.cpp
@@ -361,10 +361,10 @@ void LuaTools::Open(lua_State *L)
 		LFUNC(exists),
 #undef LFUNC
 		{ "free", ffree },
-		{ NULL, NULL }
+		{ nullptr, nullptr }
 	};
 	lua_newtable(L);
-	luaL_register(L, NULL, reg);
+	luaL_register(L, nullptr, reg);
 	lua_setglobal(L, "tools");
 	auto &toolList = lsi->gameModel->GetTools();
 	for (int i = 0; i < int(toolList.size()); ++i)

--- a/src/lua/LuaWindow.cpp
+++ b/src/lua/LuaWindow.cpp
@@ -32,7 +32,7 @@ Luna<LuaWindow>::RegType LuaWindow::methods[] = {
 	method(LuaWindow, onMouseWheel),
 	method(LuaWindow, onKeyPress),
 	method(LuaWindow, onKeyRelease),
-	{0, 0}
+	{nullptr, nullptr}
 };
 
 LuaWindow::LuaWindow(lua_State *L)

--- a/src/lua/luascripts/meson.build
+++ b/src/lua/luascripts/meson.build
@@ -1,1 +1,1 @@
-luaconsole_files += to_array.process('compat.lua', extra_args: 'compat_lua')
+powder_external_files += to_array.process('compat.lua', extra_args: 'compat_lua')

--- a/src/lua/meson.build
+++ b/src/lua/meson.build
@@ -43,4 +43,4 @@ conf_data.set('LUACONSOLE', (lua_variant != 'none').to_string())
 
 subdir('luascripts')
 
-powder_files += luaconsole_files
+powder_source_files += luaconsole_files

--- a/src/meson.build
+++ b/src/meson.build
@@ -108,24 +108,26 @@ if host_platform == 'android'
 	conf_data.set('ANDROID_PROPERTIES', '\n'.join(android_properties))
 endif
 
-powder_files = files(
+powder_source_files = files(
 	'SDLCompat.cpp',
 	'PowderToySDL.cpp',
 	'PowderToy.cpp',
 	'lua/CommandInterface.cpp',
 	'lua/TPTSTypes.cpp',
 )
+powder_external_files = []
+
 if host_platform == 'emscripten'
-	powder_files += files(
+	powder_source_files += files(
 		'PowderToySDLEmscripten.cpp',
 	)
 else
-	powder_files += files(
+	powder_source_files += files(
 		'PowderToySDLCommon.cpp',
 	)
 endif
 if is_x86
-	powder_files += files('X86KillDenormals.cpp')
+	powder_source_files += files('X86KillDenormals.cpp')
 endif
 
 render_files = files(
@@ -162,7 +164,7 @@ else
 endif
 
 if host_platform == 'linux'
-	powder_files += files('WindowIcon.cpp')
+	powder_source_files += files('WindowIcon.cpp')
 	font_files += files('WindowIcon.cpp')
 endif
 
@@ -177,7 +179,7 @@ if lua_variant != 'none'
 	subdir('lua')
 	conf_data.set('LUACONSOLE', 'true')
 else
-	powder_files += files(
+	powder_source_files += files(
 		'lua/PlainCommandInterface.cpp',
 	)
 	conf_data.set('LUACONSOLE', 'false')
@@ -187,7 +189,7 @@ subdir('resampler')
 subdir('simulation')
 subdir('tasks')
 
-powder_files += common_files
+powder_source_files += common_files
 render_files += common_files
 font_files += common_files
 

--- a/src/prefs/meson.build
+++ b/src/prefs/meson.build
@@ -1,3 +1,3 @@
-powder_files += files(
+powder_source_files += files(
 	'Prefs.cpp',
 )

--- a/src/resampler/meson.build
+++ b/src/resampler/meson.build
@@ -2,6 +2,6 @@ resampler_files = files(
 	'resampler.cpp',
 )
 
-powder_files += resampler_files
+powder_source_files += resampler_files
 render_files += resampler_files
 font_files += resampler_files

--- a/src/resampler/resampler.cpp
+++ b/src/resampler/resampler.cpp
@@ -449,14 +449,14 @@ Resampler::Contrib_List* Resampler::make_clist(
    Contrib* Pcpool_next;
    Contrib_Bounds* Pcontrib_bounds;
 
-   if ((Pcontrib = (Contrib_List*)calloc(dst_x, sizeof(Contrib_List))) == NULL)
-      return NULL;
+   if ((Pcontrib = (Contrib_List*)calloc(dst_x, sizeof(Contrib_List))) == nullptr)
+      return nullptr;
 
    Pcontrib_bounds = (Contrib_Bounds*)calloc(dst_x, sizeof(Contrib_Bounds));
    if (!Pcontrib_bounds)
    {
       free(Pcontrib);
-      return (NULL);
+      return (nullptr);
    }
 
    const Resample_Real oo_filter_scale = 1.0f / filter_scale;
@@ -496,11 +496,11 @@ Resampler::Contrib_List* Resampler::make_clist(
 
       /* Allocate memory for contributors. */
 
-      if ((n == 0) || ((Pcpool = (Contrib*)calloc(n, sizeof(Contrib))) == NULL))
+      if ((n == 0) || ((Pcpool = (Contrib*)calloc(n, sizeof(Contrib))) == nullptr))
       {
          free(Pcontrib);
          free(Pcontrib_bounds);
-         return NULL;
+         return nullptr;
       }
       total = n;
 
@@ -578,7 +578,7 @@ Resampler::Contrib_List* Resampler::make_clist(
             free(Pcpool);
             free(Pcontrib);
             free(Pcontrib_bounds);
-            return NULL;
+            return nullptr;
          }
 
          if (total_weight != 1.0f)
@@ -616,11 +616,11 @@ Resampler::Contrib_List* Resampler::make_clist(
       /* Allocate memory for contributors. */
 
       int total = n;
-      if ((total == 0) || ((Pcpool = (Contrib*)calloc(total, sizeof(Contrib))) == NULL))
+      if ((total == 0) || ((Pcpool = (Contrib*)calloc(total, sizeof(Contrib))) == nullptr))
       {
          free(Pcontrib);
          free(Pcontrib_bounds);
-         return NULL;
+         return nullptr;
       }
 
       Pcpool_next = Pcpool;
@@ -698,7 +698,7 @@ Resampler::Contrib_List* Resampler::make_clist(
             free(Pcpool);
             free(Pcontrib);
             free(Pcontrib_bounds);
-            return NULL;
+            return nullptr;
          }
 
          if (total_weight != 1.0f)
@@ -870,7 +870,7 @@ bool Resampler::put_line(const Sample* Psrc)
 
    if (!m_Pscan_buf->scan_buf_l[i])
    {
-      if ((m_Pscan_buf->scan_buf_l[i] = (Sample*)malloc(m_intermediate_x * sizeof(Sample))) == NULL)
+      if ((m_Pscan_buf->scan_buf_l[i] = (Sample*)malloc(m_intermediate_x * sizeof(Sample))) == nullptr)
       {
          m_status = STATUS_OUT_OF_MEMORY;
          return false;
@@ -907,7 +907,7 @@ const Resampler::Sample* Resampler::get_line()
    */
 
    if (m_cur_dst_y == m_resample_dst_y)
-      return NULL;
+      return nullptr;
 
    /* Check to see if all the required
    * contributors are present, if not,
@@ -916,7 +916,7 @@ const Resampler::Sample* Resampler::get_line()
 
    for (i = 0; i < m_Pclist_y[m_cur_dst_y].n; i++)
       if (!m_Psrc_y_flag[resampler_range_check(m_Pclist_y[m_cur_dst_y].p[i].pixel, m_resample_src_y)])
-         return NULL;
+         return nullptr;
 
    resample_y(m_Pdst_buf);
 
@@ -934,12 +934,12 @@ Resampler::~Resampler()
 #endif
 
    free(m_Pdst_buf);
-   m_Pdst_buf = NULL;
+   m_Pdst_buf = nullptr;
 
    if (m_Ptmp_buf)
    {
       free(m_Ptmp_buf);
-      m_Ptmp_buf = NULL;
+      m_Ptmp_buf = nullptr;
    }
 
    /* Don't deallocate a contibutor list
@@ -950,21 +950,21 @@ Resampler::~Resampler()
    {
       free(m_Pclist_x->p);
       free(m_Pclist_x);
-      m_Pclist_x = NULL;
+      m_Pclist_x = nullptr;
    }
 
    if ((m_Pclist_y) && (!m_clist_y_forced))
    {
       free(m_Pclist_y->p);
       free(m_Pclist_y);
-      m_Pclist_y = NULL;
+      m_Pclist_y = nullptr;
    }
 
    free(m_Psrc_y_count);
-   m_Psrc_y_count = NULL;
+   m_Psrc_y_count = nullptr;
 
    free(m_Psrc_y_flag);
-   m_Psrc_y_flag = NULL;
+   m_Psrc_y_flag = nullptr;
 
    if (m_Pscan_buf)
    {
@@ -972,7 +972,7 @@ Resampler::~Resampler()
          free(m_Pscan_buf->scan_buf_l[i]);
 
       free(m_Pscan_buf);
-      m_Pscan_buf = NULL;
+      m_Pscan_buf = nullptr;
    }
 }
 
@@ -1001,7 +1001,7 @@ void Resampler::restart()
       m_Pscan_buf->scan_buf_y[i] = -1;
 
       free(m_Pscan_buf->scan_buf_l[i]);
-      m_Pscan_buf->scan_buf_l[i] = NULL;
+      m_Pscan_buf->scan_buf_l[i] = nullptr;
    }
 }
 
@@ -1034,15 +1034,15 @@ Resampler::Resampler(int src_x, int src_y,
 
    m_delay_x_resample = false;
    m_intermediate_x = 0;
-   m_Pdst_buf = NULL;
-   m_Ptmp_buf = NULL;
+   m_Pdst_buf = nullptr;
+   m_Ptmp_buf = nullptr;
    m_clist_x_forced = false;
-   m_Pclist_x = NULL;
+   m_Pclist_x = nullptr;
    m_clist_y_forced = false;
-   m_Pclist_y = NULL;
-   m_Psrc_y_count = NULL;
-   m_Psrc_y_flag = NULL;
-   m_Pscan_buf = NULL;
+   m_Pclist_y = nullptr;
+   m_Psrc_y_count = nullptr;
+   m_Psrc_y_flag = nullptr;
+   m_Pscan_buf = nullptr;
    m_status = STATUS_OKAY;
 
    m_resample_src_x = src_x;
@@ -1052,7 +1052,7 @@ Resampler::Resampler(int src_x, int src_y,
 
    m_boundary_op = boundary_op;
 
-   if ((m_Pdst_buf = (Sample*)malloc(m_resample_dst_x * sizeof(Sample))) == NULL)
+   if ((m_Pdst_buf = (Sample*)malloc(m_resample_dst_x * sizeof(Sample))) == nullptr)
    {
       m_status = STATUS_OUT_OF_MEMORY;
       return;
@@ -1060,7 +1060,7 @@ Resampler::Resampler(int src_x, int src_y,
 
    // Find the specified filter.
 
-   if (Pfilter_name == NULL)
+   if (Pfilter_name == nullptr)
       Pfilter_name = RESAMPLER_DEFAULT_FILTER;
 
    for (i = 0; i < NUM_FILTERS; i++)
@@ -1108,13 +1108,13 @@ Resampler::Resampler(int src_x, int src_y,
       m_clist_y_forced = true;
    }
 
-   if ((m_Psrc_y_count = (int*)calloc(m_resample_src_y, sizeof(int))) == NULL)
+   if ((m_Psrc_y_count = (int*)calloc(m_resample_src_y, sizeof(int))) == nullptr)
    {
       m_status = STATUS_OUT_OF_MEMORY;
       return;
    }
 
-   if ((m_Psrc_y_flag = (unsigned char*)calloc(m_resample_src_y, sizeof(unsigned char))) == NULL)
+   if ((m_Psrc_y_flag = (unsigned char*)calloc(m_resample_src_y, sizeof(unsigned char))) == nullptr)
    {
       m_status = STATUS_OUT_OF_MEMORY;
       return;
@@ -1128,7 +1128,7 @@ Resampler::Resampler(int src_x, int src_y,
       for (j = 0; j < m_Pclist_y[i].n; j++)
          m_Psrc_y_count[resampler_range_check(m_Pclist_y[i].p[j].pixel, m_resample_src_y)]++;
 
-   if ((m_Pscan_buf = (Scan_Buf*)malloc(sizeof(Scan_Buf))) == NULL)
+   if ((m_Pscan_buf = (Scan_Buf*)malloc(sizeof(Scan_Buf))) == nullptr)
    {
       m_status = STATUS_OUT_OF_MEMORY;
       return;
@@ -1137,7 +1137,7 @@ Resampler::Resampler(int src_x, int src_y,
    for (i = 0; i < MAX_SCAN_BUF_SIZE; i++)
    {
       m_Pscan_buf->scan_buf_y[i] = -1;
-      m_Pscan_buf->scan_buf_l[i] = NULL;
+      m_Pscan_buf->scan_buf_l[i] = nullptr;
    }
 
    m_cur_src_y = m_cur_dst_y = 0;
@@ -1185,7 +1185,7 @@ Resampler::Resampler(int src_x, int src_y,
 
    if (m_delay_x_resample)
    {
-      if ((m_Ptmp_buf = (Sample*)malloc(m_intermediate_x * sizeof(Sample))) == NULL)
+      if ((m_Ptmp_buf = (Sample*)malloc(m_intermediate_x * sizeof(Sample))) == nullptr)
       {
          m_status = STATUS_OUT_OF_MEMORY;
          return;
@@ -1210,7 +1210,7 @@ int Resampler::get_filter_num()
 char* Resampler::get_filter_name(int filter_num)
 {
    if ((filter_num < 0) || (filter_num >= NUM_FILTERS))
-      return NULL;
+      return nullptr;
    else
       return g_filters[filter_num].name;
 }

--- a/src/simulation/Editing.cpp
+++ b/src/simulation/Editing.cpp
@@ -292,7 +292,7 @@ void Simulation::CreateWallBox(int x1, int y1, int x2, int y2, int wall)
 	}
 	for (j=y1; j<=y2; j++)
 		for (i=x1; i<=x2; i++)
-			CreateWalls(i, j, 0, 0, wall, NULL);
+			CreateWalls(i, j, 0, 0, wall, nullptr);
 }
 
 int Simulation::FloodWalls(int x, int y, int wall, int bm)
@@ -335,7 +335,7 @@ int Simulation::FloodWalls(int x, int y, int wall, int bm)
 	// fill span
 	for (x=x1; x<=x2; x++)
 	{
-		if (!CreateWalls(x, y, 0, 0, wall, NULL))
+		if (!CreateWalls(x, y, 0, 0, wall, nullptr))
 			return 0;
 	}
 	// fill children

--- a/src/simulation/SimTool.cpp
+++ b/src/simulation/SimTool.cpp
@@ -4,7 +4,7 @@
 
 void SimTool::CallPerform(Simulation *sim, ui::Point position, ui::Point brushOffset)
 {
-	Particle * cpart = NULL;
+	Particle * cpart = nullptr;
 	int r;
 	if ((r = sim->pmap[position.Y][position.X]))
 		cpart = &(sim->parts[ID(r)]);

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -1584,7 +1584,7 @@ int Simulation::is_blocking(int t, int x, int y) const
 		return 0;
 	}
 
-	return !eval_move(t, x, y, NULL);
+	return !eval_move(t, x, y, nullptr);
 }
 
 int Simulation::is_boundary(int pt, int x, int y) const
@@ -1871,7 +1871,7 @@ int Simulation::create_part(int p, int x, int y, int t, int v)
 		// If there isn't a particle but there is a wall, check whether the new particle is allowed to be in it
 		//   (not "!=2" for wall check because eval_move returns 1 for moving into empty space)
 		// If there's no particle and no wall, assume creation is allowed
-		if (pmap[y][x] ? (eval_move(t, x, y, NULL) != 2) : (bmap[y/CELL][x/CELL] && eval_move(t, x, y, NULL) == 0))
+		if (pmap[y][x] ? (eval_move(t, x, y, nullptr) != 2) : (bmap[y/CELL][x/CELL] && eval_move(t, x, y, nullptr) == 0))
 		{
 			return -1;
 		}
@@ -2196,7 +2196,7 @@ Simulation::PlanMoveResult Simulation::PlanMove(Sim &sim, int i, int x, int y)
 			}
 			//block if particle can't move (0), or some special cases where it returns 1 (can_move = 3 but returns 1 meaning particle will be eaten)
 			//also photons are still blocked (slowed down) by any particle (even ones it can move through), and absorb wall also blocks particles
-			int eval = sim.eval_move(t, fin_x, fin_y, NULL);
+			int eval = sim.eval_move(t, fin_x, fin_y, nullptr);
 			if (!eval || (can_move[t][TYP(pmap[fin_y][fin_x])] == 3 && eval == 1) || (t == PT_PHOT && pmap[fin_y][fin_x]) || bmap[fin_y/CELL][fin_x/CELL]==WL_DESTROYALL || closedEholeStart!=(bmap[fin_y/CELL][fin_x/CELL] == WL_EHOLE && !emap[fin_y/CELL][fin_x/CELL]))
 			{
 				// found an obstacle
@@ -2938,7 +2938,7 @@ killed:
 					if (!x_ok || !y_ok) //when moving from left to right stickmen might be able to fall through solid things, fix with "eval_move(t, nx+diffx, ny+diffy, NULL)" but then they die instead
 					{
 						//adjust stickmen legs
-						playerst* stickman = NULL;
+						playerst* stickman = nullptr;
 						int t = parts[i].type;
 						if (t == PT_STKM)
 							stickman = &player;
@@ -2985,7 +2985,7 @@ killed:
 						continue;
 					}
 
-					if (eval_move(PT_PHOT, fin_x, fin_y, NULL))
+					if (eval_move(PT_PHOT, fin_x, fin_y, nullptr))
 					{
 						int rt = TYP(pmap[fin_y][fin_x]);
 						int lt = TYP(pmap[y][x]);

--- a/src/simulation/elements/DUST.cpp
+++ b/src/simulation/elements/DUST.cpp
@@ -41,5 +41,5 @@ void Element::Element_DUST()
 	HighTemperature = ITH;
 	HighTemperatureTransition = NT;
 
-	Graphics = NULL; // it this needed?
+	Graphics = nullptr; // it this needed?
 }

--- a/src/simulation/elements/FIGH.cpp
+++ b/src/simulation/elements/FIGH.cpp
@@ -107,8 +107,8 @@ static int update(UPDATE_FUNC_ARGS)
 		}
 		else if (tarx<x)
 		{
-			if(figh->rocketBoots || !(sim->eval_move(PT_FIGH, int(figh->legs[4])-10, int(figh->legs[5])+6, NULL)
-			     && sim->eval_move(PT_FIGH, int(figh->legs[4])-10, int(figh->legs[5])+3, NULL)))
+			if(figh->rocketBoots || !(sim->eval_move(PT_FIGH, int(figh->legs[4])-10, int(figh->legs[5])+6, nullptr)
+			     && sim->eval_move(PT_FIGH, int(figh->legs[4])-10, int(figh->legs[5])+3, nullptr)))
 				figh->comm = 0x01;
 			else
 				figh->comm = 0x02;
@@ -118,15 +118,15 @@ static int update(UPDATE_FUNC_ARGS)
 				if (tary<y)
 					figh->comm = (int)figh->comm | 0x04;
 			}
-			else if (!sim->eval_move(PT_FIGH, int(figh->legs[4])-4, int(figh->legs[5])-1, NULL)
-			    || !sim->eval_move(PT_FIGH, int(figh->legs[12])-4, int(figh->legs[13])-1, NULL)
-			    || sim->eval_move(PT_FIGH, 2*int(figh->legs[4])-int(figh->legs[6]), int(figh->legs[5])+5, NULL))
+			else if (!sim->eval_move(PT_FIGH, int(figh->legs[4])-4, int(figh->legs[5])-1, nullptr)
+			    || !sim->eval_move(PT_FIGH, int(figh->legs[12])-4, int(figh->legs[13])-1, nullptr)
+			    || sim->eval_move(PT_FIGH, 2*int(figh->legs[4])-int(figh->legs[6]), int(figh->legs[5])+5, nullptr))
 				figh->comm = (int)figh->comm | 0x04;
 		}
 		else
 		{
-			if (figh->rocketBoots || !(sim->eval_move(PT_FIGH, int(figh->legs[12])+10, int(figh->legs[13])+6, NULL)
-			      && sim->eval_move(PT_FIGH, int(figh->legs[12])+10, int(figh->legs[13])+3, NULL)))
+			if (figh->rocketBoots || !(sim->eval_move(PT_FIGH, int(figh->legs[12])+10, int(figh->legs[13])+6, nullptr)
+			      && sim->eval_move(PT_FIGH, int(figh->legs[12])+10, int(figh->legs[13])+3, nullptr)))
 				figh->comm = 0x02;
 			else
 				figh->comm = 0x01;
@@ -136,9 +136,9 @@ static int update(UPDATE_FUNC_ARGS)
 				if (tary<y)
 					figh->comm = (int)figh->comm | 0x04;
 			}
-			else if (!sim->eval_move(PT_FIGH, int(figh->legs[4])+4, int(figh->legs[5])-1, NULL)
-			    || !sim->eval_move(PT_FIGH, int(figh->legs[4])+4, int(figh->legs[5])-1, NULL)
-			    || sim->eval_move(PT_FIGH, 2*int(figh->legs[12])-int(figh->legs[14]), int(figh->legs[13])+5, NULL))
+			else if (!sim->eval_move(PT_FIGH, int(figh->legs[4])+4, int(figh->legs[5])-1, nullptr)
+			    || !sim->eval_move(PT_FIGH, int(figh->legs[4])+4, int(figh->legs[5])-1, nullptr)
+			    || sim->eval_move(PT_FIGH, 2*int(figh->legs[12])-int(figh->legs[14]), int(figh->legs[13])+5, nullptr))
 				figh->comm = (int)figh->comm | 0x04;
 		}
 		break;

--- a/src/simulation/elements/FWRK.cpp
+++ b/src/simulation/elements/FWRK.cpp
@@ -62,7 +62,7 @@ static int update(UPDATE_FUNC_ARGS)
 			gy += cosf(angle)*elements[PT_FWRK].Gravity*0.5f;
 		}
 		gmax = std::max(fabsf(gx), fabsf(gy));
-		if (sim->eval_move(PT_FWRK, (int)(x-(gx/gmax)+0.5f), (int)(y-(gy/gmax)+0.5f), NULL))
+		if (sim->eval_move(PT_FWRK, (int)(x-(gx/gmax)+0.5f), (int)(y-(gy/gmax)+0.5f), nullptr))
 		{
 			multiplier = 15.0f/sqrtf(gx*gx+gy*gy);
 

--- a/src/simulation/elements/SAWD.cpp
+++ b/src/simulation/elements/SAWD.cpp
@@ -40,5 +40,5 @@ void Element::Element_SAWD()
 	HighTemperature = ITH;
 	HighTemperatureTransition = NT;
 
-	Graphics = NULL; // is this needed?
+	Graphics = nullptr; // is this needed?
 }

--- a/src/simulation/elements/STKM.cpp
+++ b/src/simulation/elements/STKM.cpp
@@ -251,7 +251,7 @@ int Element_STKM_run_stickman(playerst *playerp, UPDATE_FUNC_ARGS)
 		bool moved = false;
 		if (dl>dr)
 		{
-			if (InBounds(int(playerp->legs[4]), int(playerp->legs[5])) && !sim->eval_move(t, int(playerp->legs[4]), int(playerp->legs[5]), NULL))
+			if (InBounds(int(playerp->legs[4]), int(playerp->legs[5])) && !sim->eval_move(t, int(playerp->legs[4]), int(playerp->legs[5]), nullptr))
 			{
 				playerp->accs[2] = -3*mvy-3*mvx;
 				playerp->accs[3] = 3*mvx-3*mvy;
@@ -262,7 +262,7 @@ int Element_STKM_run_stickman(playerst *playerp, UPDATE_FUNC_ARGS)
 		}
 		else
 		{
-			if (InBounds(int(playerp->legs[12]), int(playerp->legs[13])) && !sim->eval_move(t, int(playerp->legs[12]), int(playerp->legs[13]), NULL))
+			if (InBounds(int(playerp->legs[12]), int(playerp->legs[13])) && !sim->eval_move(t, int(playerp->legs[12]), int(playerp->legs[13]), nullptr))
 			{
 				playerp->accs[6] = -3*mvy-3*mvx;
 				playerp->accs[7] = 3*mvx-3*mvy;
@@ -301,7 +301,7 @@ int Element_STKM_run_stickman(playerst *playerp, UPDATE_FUNC_ARGS)
 		bool moved = false;
 		if (dl<dr)
 		{
-			if (InBounds(int(playerp->legs[4]), int(playerp->legs[5])) && !sim->eval_move(t, int(playerp->legs[4]), int(playerp->legs[5]), NULL))
+			if (InBounds(int(playerp->legs[4]), int(playerp->legs[5])) && !sim->eval_move(t, int(playerp->legs[4]), int(playerp->legs[5]), nullptr))
 			{
 				playerp->accs[2] = 3*mvy-3*mvx;
 				playerp->accs[3] = -3*mvx-3*mvy;
@@ -312,7 +312,7 @@ int Element_STKM_run_stickman(playerst *playerp, UPDATE_FUNC_ARGS)
 		}
 		else
 		{
-			if (InBounds(int(playerp->legs[12]), int(playerp->legs[13])) && !sim->eval_move(t, int(playerp->legs[12]), int(playerp->legs[13]), NULL))
+			if (InBounds(int(playerp->legs[12]), int(playerp->legs[13])) && !sim->eval_move(t, int(playerp->legs[12]), int(playerp->legs[13]), nullptr))
 			{
 				playerp->accs[6] = 3*mvy-3*mvx;
 				playerp->accs[7] = -3*mvx-3*mvy;
@@ -378,8 +378,8 @@ int Element_STKM_run_stickman(playerst *playerp, UPDATE_FUNC_ARGS)
 				}
 			}
 		}
-		else if ((InBounds(int(playerp->legs[4]), int(playerp->legs[5])) && !sim->eval_move(t, int(playerp->legs[4]), int(playerp->legs[5]), NULL)) ||
-				 (InBounds(int(playerp->legs[12]), int(playerp->legs[13])) && !sim->eval_move(t, int(playerp->legs[12]), int(playerp->legs[13]), NULL)))
+		else if ((InBounds(int(playerp->legs[4]), int(playerp->legs[5])) && !sim->eval_move(t, int(playerp->legs[4]), int(playerp->legs[5]), nullptr)) ||
+				 (InBounds(int(playerp->legs[12]), int(playerp->legs[13])) && !sim->eval_move(t, int(playerp->legs[12]), int(playerp->legs[13]), nullptr)))
 		{
 			parts[i].vx -= 4*mvx;
 			parts[i].vy -= 4*mvy;
@@ -551,27 +551,27 @@ int Element_STKM_run_stickman(playerst *playerp, UPDATE_FUNC_ARGS)
 	playerp->legs[8] += (playerp->legs[8]-parts[i].x)*d;
 	playerp->legs[9] += (playerp->legs[9]-parts[i].y)*d;
 
-	if (InBounds(int(playerp->legs[4]), int(playerp->legs[5])) && !sim->eval_move(t, int(playerp->legs[4]), int(playerp->legs[5]), NULL))
+	if (InBounds(int(playerp->legs[4]), int(playerp->legs[5])) && !sim->eval_move(t, int(playerp->legs[4]), int(playerp->legs[5]), nullptr))
 	{
 		playerp->legs[4] = playerp->legs[6];
 		playerp->legs[5] = playerp->legs[7];
 	}
 
-	if (InBounds(int(playerp->legs[12]), int(playerp->legs[13])) && !sim->eval_move(t, int(playerp->legs[12]), int(playerp->legs[13]), NULL))
+	if (InBounds(int(playerp->legs[12]), int(playerp->legs[13])) && !sim->eval_move(t, int(playerp->legs[12]), int(playerp->legs[13]), nullptr))
 	{
 		playerp->legs[12] = playerp->legs[14];
 		playerp->legs[13] = playerp->legs[15];
 	}
 
 	//This makes stick man "pop" from obstacles
-	if (InBounds(int(playerp->legs[4]), int(playerp->legs[5])) && !sim->eval_move(t, int(playerp->legs[4]), int(playerp->legs[5]), NULL))
+	if (InBounds(int(playerp->legs[4]), int(playerp->legs[5])) && !sim->eval_move(t, int(playerp->legs[4]), int(playerp->legs[5]), nullptr))
 	{
 		float t;
 		t = playerp->legs[4]; playerp->legs[4] = playerp->legs[6]; playerp->legs[6] = t;
 		t = playerp->legs[5]; playerp->legs[5] = playerp->legs[7]; playerp->legs[7] = t;
 	}
 
-	if (InBounds(int(playerp->legs[12]), int(playerp->legs[13])) && !sim->eval_move(t, int(playerp->legs[12]), int(playerp->legs[13]), NULL))
+	if (InBounds(int(playerp->legs[12]), int(playerp->legs[13])) && !sim->eval_move(t, int(playerp->legs[12]), int(playerp->legs[13]), nullptr))
 	{
 		float t;
 		t = playerp->legs[12]; playerp->legs[12] = playerp->legs[14]; playerp->legs[14] = t;

--- a/src/simulation/gravity/meson.build
+++ b/src/simulation/gravity/meson.build
@@ -5,5 +5,5 @@ if host_platform == 'emscripten'
 else
 	conf_data.set('FFTW_PLAN_MEASURE', 'true')
 endif
-powder_files += files('Fft.cpp')
+powder_source_files += files('Fft.cpp')
 render_files += files('Null.cpp')

--- a/src/simulation/meson.build
+++ b/src/simulation/meson.build
@@ -14,10 +14,10 @@ subdir('elements')
 subdir('simtools')
 subdir('gravity')
 
-powder_files += simulation_files
+powder_source_files += simulation_files
 render_files += simulation_files
 
-powder_files += files(
+powder_source_files += files(
 	'Editing.cpp',
 	'SimTool.cpp',
 	'ToolClasses.cpp',

--- a/src/tasks/Task.cpp
+++ b/src/tasks/Task.cpp
@@ -89,7 +89,7 @@ Task::Task() :
 	done(false),
 	thProgress(0),
 	thDone(false),
-	listener(NULL)
+	listener(nullptr)
 {
 }
 

--- a/src/tasks/meson.build
+++ b/src/tasks/meson.build
@@ -1,4 +1,4 @@
-powder_files += files(
+powder_source_files += files(
 	'AbandonableTask.cpp',
 	'Task.cpp',
 	'TaskWindow.cpp',


### PR DESCRIPTION
Split powder_files into source and external files

Right now, there's only a big list of files to be compiled into an
executable. Most are .cpp files, but some are python scripts and other
things that aren't source code.

In order to run clang-tidy, we must assemble a list that only contains
source files.

Add clang-tidy support

Run meson compile clang-tidy in the build directory to lint your code
for issues. Currently, clang-tidy is configured not to check for
anything, so the command will fail.

Lint for modernize-use-nullptr

C++11 standardizes the "nullptr" keyword, which replaces the
implementation-defined macro null pointer "NULL" or a hardcoded 0.